### PR TITLE
Add Python 3.13 support to build matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'macos-12' ]
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
   
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pip install pyrealsense2-macosx
 
 - OS: *macOS Catalina*[*](#older-macos-and-python-) (`10.15`), *macOS Big Sur*[*](#older-macos-and-python-) (`11`), macOS Monterey (`12`) and higher
 - Architecture: `Intel (x86_64)`, `Apple Silicon (arm64)`
-- Python: `3.6`\*, `3.7`\*, `3.8`, `3.9`, `3.10`, `3.11`, `3.12`
+- Python: `3.6`\*, `3.7`\*, `3.8`, `3.9`, `3.10`, `3.11`, `3.12`, `3.13`
 
 #### requirements.txt
 


### PR DESCRIPTION
## Summary
- Add Python 3.13 to the GitHub Actions build matrix
- Update README.md to document Python 3.13 support

## Details
This PR extends the build pipeline to support Python 3.13. The build script already handles Python 3.13 correctly, as it uses the modern `bdist_wheel` approach for Python >= 3.11.

## Changes
1. **GitHub Actions Workflow** (`.github/workflows/main.yml`): Added `'3.13'` to the Python version matrix
2. **Documentation** (`README.md`): Updated supported Python versions to include `3.13`

## Compatibility Notes
- The existing build script (`librealsense-python-mac.ps1`) already has the correct version detection logic for Python 3.13
- Python 3.13 will follow the same build path as Python 3.11 and 3.12 (standard wheel building)
- The script installs `wheel` package explicitly (line 160), so no additional changes are needed

## Testing
The changes are minimal and backward compatible. The actual build success will depend on Intel's librealsense C++ library supporting Python 3.13's C API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)